### PR TITLE
Fixed checklist output

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ To create an unordered list, add dashes (-), asterisks (*), or plus signs (+) in
 To create a checklist, add a dash and brackets with a space or `x` in front of line items.
 | Markdown                            | HTML | Output |
 |-------------------------------------|------|--------|
-| `- [ ]` Unchecked item |`<input type="checkbox" unchecked>`<br> `<label>Unchecked Item</label>`<br> | <input type="checkbox" disabled="disabled" unchecked> Unchecked item |
-| `- [x]` Checked item |`<input type="checkbox" checked>`<br> `<label>Checked Item</label>`<br> | <input type="checkbox" disabled="disabled" checked> Checked item |
+| `- [ ]` Unchecked item |`<input type="checkbox" unchecked>`<br> `<label>Unchecked Item</label>`<br> | :white_large_square: Unchecked item |
+| `- [x]` Checked item |`<input type="checkbox" checked>`<br> `<label>Checked Item</label>`<br> | :ballot_box_with_check: Checked item |
 
 *****
 


### PR DESCRIPTION
After merging #4 I noticed that the checkboxes were not visible in the output of the checklist subsection. They were visible in the VS Code preview but not in GitHub. Below is a screenshot from my end:

![image](https://github.com/NyanKaungSet/Markdown/assets/108101472/698cb5ba-19fb-4842-9558-72c17a67af92)

Here is information I found discussing a lack of support for checkboxes in tables in Markdown (Note that the previous solution and `<ul><li>- [ ]</li></ul>` do not work):

https://stackoverflow.com/questions/47344571/how-to-draw-checkbox-or-tick-mark-in-github-markdown-table/63206994#63206994

I've opted for the solution of using emojis to display the output as it looked the most consistent with the expected output. Below is a screenshot:

![image](https://github.com/NyanKaungSet/Markdown/assets/108101472/149cfd33-bf15-48c3-b48c-66b72bc04b39)